### PR TITLE
MNT improve test report in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ env:
   FORCE_COLOR: "1"
 
 jobs:
-  run:
+  run-test-suite:
     name: Python ${{ matrix.python-version }} on ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,6 @@ jobs:
       inputs:
         testResultsFormat: 'JUnit'
         testResultsFiles: 'pytest.xml'
-        testRunTitle: ${{ format('{0}-{1}-$(Agent.JobName)', matrix.python-version, runner.os) }}
+        # testRunTitle: ${{ format('{0}-{1}-$(Agent.JobName)', matrix.python-version, runner.os) }}
       displayName: 'Publish Test Results'
       condition: succeededOrFailed()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,12 @@ jobs:
       run: hatch run lint:all
 
     - name: Run tests
-      run: hatch run cov
+      run: hatch run cov --junitxml=pytest.xml
+
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFormat: 'JUnit'
+        testResultsFiles: 'pytest.xml'
+        testRunTitle: ${{ format('{0}-{1}-$(Agent.JobName)', matrix.python-version, runner.os) }}
+      displayName: 'Publish Test Results'
+      condition: succeededOrFailed()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,10 +44,10 @@ jobs:
     - name: Run tests
       run: hatch run cov --junitxml=pytest.xml
 
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFormat: 'JUnit'
-        testResultsFiles: 'pytest.xml'
-        # testRunTitle: ${{ format('{0}-{1}-$(Agent.JobName)', matrix.python-version, runner.os) }}
-      displayName: 'Publish Test Results'
-      condition: succeededOrFailed()
+    # - task: PublishTestResults@2
+    #   inputs:
+    #     testResultsFormat: 'JUnit'
+    #     testResultsFiles: 'pytest.xml'
+    #     # testRunTitle: ${{ format('{0}-{1}-$(Agent.JobName)', matrix.python-version, runner.os) }}
+    #   displayName: 'Publish Test Results'
+    #   condition: succeededOrFailed()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,12 +42,4 @@ jobs:
       run: hatch run lint:all
 
     - name: Run tests
-      run: hatch run cov --junitxml=pytest.xml
-
-    # - task: PublishTestResults@2
-    #   inputs:
-    #     testResultsFormat: 'JUnit'
-    #     testResultsFiles: 'pytest.xml'
-    #     # testRunTitle: ${{ format('{0}-{1}-$(Agent.JobName)', matrix.python-version, runner.os) }}
-    #   displayName: 'Publish Test Results'
-    #   condition: succeededOrFailed()
+      run: hatch run cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,8 @@ dependencies = [
 ]
 
 [tool.hatch.envs.default.scripts]
-cov = "pytest  -n auto --cov-report=term-missing --cov-config=pyproject.toml --cov=src/model_diagnostics {args}"
+# Adding "-n auto" (pytest-xdist) allows parallel execution but swallows output.
+cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=src/model_diagnostics {args}"
 no-cov = "cov --no-cov"
 
 [tool.hatch.envs.docs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
 ]
 
 [tool.hatch.envs.default.scripts]
-cov = "pytest  -n auto --cov-report=term-missing --cov-config=pyproject.toml --cov=src/model_diagnostics"
+cov = "pytest  -n auto --cov-report=term-missing --cov-config=pyproject.toml --cov=src/model_diagnostics {args}"
 no-cov = "cov --no-cov"
 
 [tool.hatch.envs.docs]


### PR DESCRIPTION
pytest-xdist does suppress useful test output. As tests are pretty fast so far, we refrain from using parallel tests.