### PR TITLE
FIX pyarrow dependency in pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "polars>=0.17.3",
   "scikit-learn>=1.2.0",  # We rely on the set_output API.
   "scipy>=1.10",  # scipy.stats.expectile
+  "pyarrow>=11.0.0",
 ]
 dynamic = ["version"]
 

--- a/src/model_diagnostics/calibration/identification.py
+++ b/src/model_diagnostics/calibration/identification.py
@@ -485,13 +485,13 @@ def compute_bias(
             stderr_ = df.get_column("bias_stderr")
             p_value = np.full_like(stderr_, fill_value=np.nan)
             n = df.get_column("bias_count")
-            p_value[(n > 1) & (stderr_ == 0)] = 0
+            p_value[((n > 1) & (stderr_ == 0)).to_numpy().astype(bool)] = 0
             mask = stderr_ > 0
             x = df.get_column("bias_mean").filter(mask).to_numpy()
             n = df.get_column("bias_count").filter(mask).to_numpy()
             stderr = stderr_.filter(mask).to_numpy()
             # t-statistic t (-|t| and factor of 2 because of 2-sided test)
-            p_value[mask] = 2 * special.stdtr(
+            p_value[mask.to_numpy().astype(bool)] = 2 * special.stdtr(
                 n - 1,  # degrees of freedom
                 -np.abs(x / stderr),
             )


### PR DESCRIPTION
To install pyarrow as a dependency when calling `pip install`, otherwise `compute_bias` might raise an error.
@lorentzenchr this should close issue #109 

I just added line 30 and then perhaps github shows the new line at the end (250 in the new file) as a diff?