### PR TITLE
FIX raise informed error in decompose when recalibrated out of range

### DIFF
--- a/src/model_diagnostics/scoring/scoring.py
+++ b/src/model_diagnostics/scoring/scoring.py
@@ -850,8 +850,8 @@ def decompose(
             scoring_function(y_o[0], marginal)
         except ValueError as exc:
             msg = (
-                "Your y_obs is constant and lies outside the allowed range of y_pred"
-                "of your scoring function. Therefore, the score decomposition cannot"
+                "Your y_obs is constant and lies outside the allowed range of y_pred "
+                "of your scoring function. Therefore, the score decomposition cannot "
                 "be applied."
             )
             raise ValueError(msg) from exc
@@ -866,7 +866,15 @@ def decompose(
         iso.fit(x, y_o, sample_weight=w)
         recalibrated = np.squeeze(iso.predict(x))
         score = scoring_function(y_o, x, w)
-        score_recalibrated = scoring_function(y_o, recalibrated, w)
+        try:
+            score_recalibrated = scoring_function(y_o, recalibrated, w)
+        except ValueError as exc:
+            msg = (
+                "The recalibrated predictions obtained from isotonic regression are "
+                "very likely outside the allowed range of y_pred of your scoring "
+                "function. Therefore, the score decomposition cannot be applied."
+            )
+            raise ValueError(msg) from exc
 
         df = pl.DataFrame(
             {

--- a/src/model_diagnostics/scoring/tests/test_scoring.py
+++ b/src/model_diagnostics/scoring/tests/test_scoring.py
@@ -726,3 +726,16 @@ def test_decompose_constant_0_y_obs(y, sf):
             y_pred=y_pred,
             scoring_function=sf,
         )
+
+
+def test_decompose_isotonic_outside_range():
+    """Test that decompose works if isotonic regression is outside calid domain."""
+    y_obs = np.array([0.0, 1.0])
+    y_pred = np.array([0.01, 1.5])
+
+    with pytest.raises(ValueError, match="The recalibrated predictions obtained"):
+        decompose(
+            y_obs=y_obs,
+            y_pred=y_pred,
+            scoring_function=PoissonDeviance(),
+        )


### PR DESCRIPTION
Closes #108.

At least an informed error is raised. I don't see a generic way to compute the decomposition. One would need the exact boundary of the valid domain of a scoring function. Not unfeasible, but let's start with raising that error.