### PR TITLE
FIX polars 0.19.14 deprecation warnings

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -17,7 +17,7 @@ Apart from the default environment are `docs`, `jupyter`, `lint` and `test`
 
 - `hatch run cov` or `hatch run pytest` to run tests
 - `hatch -e test run pytest` to run test matrix for multiple versions of python and packages
-- `hatch run lint:fmt` to apply black and `isort`
+- `hatch run lint:fmt` to apply `black` and `isort`
 - `hatch run lint:all` to check linting, typing, style and security
 - `hatch run docs:serve` to run a local server under [localhost:8000](localhost:8000)
    for the website supporting live updates, i.e. you can change the docs and see

--- a/src/model_diagnostics/calibration/identification.py
+++ b/src/model_diagnostics/calibration/identification.py
@@ -275,10 +275,13 @@ def compute_bias(
             elif feature.dtype in [pl.Utf8, pl.Object]:
                 # We could convert strings to categoricals.
                 is_string = True
-            elif feature.is_float():
+            # FIXME: polars >= 0.19.14
+            # Then, just use Series.dtype.is_float()
+            elif (hasattr(feature.dtype, "is_float") and feature.dtype.is_float()) or (
+                not hasattr(feature.dtype, "is_float") and feature.is_float()
+            ):
                 # We treat NaN as Null values, numpy will see a Null as a NaN.
-                if feature.is_float():
-                    feature = feature.fill_nan(None)
+                feature = feature.fill_nan(None)
             else:
                 # integers
                 pass


### PR DESCRIPTION
- `take` was renamed to `gather`, see https://github.com/pola-rs/polars/releases/tag/py-0.19.14.
- `Series.is_float` is deprecated, use `Series.dtype.is_float` instead, see https://github.com/pola-rs/polars/pull/12200 in [polars 0.19.14 release](https://github.com/pola-rs/polars/releases/tag/py-0.19.14).
- Rename `Series.set_at_idx` to `scatter` in [polars 0.19.14 release](https://github.com/pola-rs/polars/releases/tag/py-0.19.14).