### PR TITLE
DOC fix typo in identification_function docstring

### DIFF
--- a/src/model_diagnostics/calibration/identification.py
+++ b/src/model_diagnostics/calibration/identification.py
@@ -68,7 +68,7 @@ def identification_function(
     \in \mathcal{F}
     \]
 
-    for some class of distribtions \(\mathcal{F}\). Implemented examples of the
+    for some class of distributions \(\mathcal{F}\). Implemented examples of the
     functional \(T\) are mean, median, expectiles and quantiles.
 
     | functional | strict identification function \(V(y, z)\)           |


### PR DESCRIPTION
Typo: currently "distribtions" instead of "distributions" in the doctoring of src/model_diagnostics/calibration/identification.py