### PR TITLE
ENH add inital plotly backend to plot_reliability_diagram

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,7 @@ ci-build = "mkdocs gh-deploy --force {args}"
 extra-dependencies = [
   "jupyterlab>=4.0.4",
   "scikit-learn>=1.3.0",
+  "plotly>=5.11.0",
 ]
 
 [tool.hatch.envs.jupyter.scripts]
@@ -247,12 +248,13 @@ name."py3.10".set-extra-dependencies = [
   "polars==0.19.19",
   "scipy==1.10",
 ]
-# latest versions
+# latest versions, with plotly
 name."py3.11".set-extra-dependencies = [
   "numpy",
   "polars",
   "scipy",
   "pandas",
+  "plotly",
   "pyarrow",
 ]
 # To check correct versions, you can run

--- a/src/model_diagnostics/calibration/tests/test_plots.py
+++ b/src/model_diagnostics/calibration/tests/test_plots.py
@@ -46,6 +46,11 @@ def get_title(ax):
         ("diagram_type", "XXX", "Parameter diagram_type must be either.*XXX"),
         ("functional", "XXX", "Argument functional must be one of.*XXX"),
         ("level", 2, "Argument level must fulfil 0 < level < 1, got 2"),
+        (
+            "ax",
+            "XXX",
+            "The ax argument must be None, a matplotlib Axes or a plotly Figure",
+        ),
         ("plot_backend", "XXX", "The plot_backend must be"),
     ],
 )
@@ -74,14 +79,18 @@ def test_plot_reliability_diagram_raises_y_obs_multdim():
 @pytest.mark.parametrize("functional", ["mean", "expectile", "quantile"])
 @pytest.mark.parametrize("n_bootstrap", [None, 10])
 @pytest.mark.parametrize("weights", [None, True])
-@pytest.mark.parametrize("ax", [None, plt.subplots()[1]])
+@pytest.mark.parametrize("ax", [None, plt.subplots()[1], "plotly"])
 @pytest.mark.parametrize("plot_backend", ["matplotlib", "plotly"])
 def test_plot_reliability_diagram(
     diagram_type, functional, n_bootstrap, weights, ax, plot_backend
 ):
     """Test that plot_reliability_diagram works."""
-    if plot_backend == "plotly":
+    if plot_backend == "plotly" or ax == "plotly":
         pytest.importorskip("plotly")
+        import plotly.graph_objects as go
+
+    if ax == "plotly":
+        ax = go.Figure()
 
     X, y = make_classification(random_state=42, n_classes=2)
     if weights is None:

--- a/src/model_diagnostics/calibration/tests/test_plots.py
+++ b/src/model_diagnostics/calibration/tests/test_plots.py
@@ -134,13 +134,11 @@ def test_plot_reliability_diagram(
     if ax is not None:
         assert ax is plt_ax
 
-    if isinstance(plt_ax, mpl.axes.Axes):
-        assert get_xlabel(plt_ax) == "prediction for " + xlabel_mapping[functional]
+    assert get_xlabel(plt_ax) == "prediction for " + xlabel_mapping[functional]
 
     if diagram_type == "reliability":
-        if isinstance(plt_ax, mpl.axes.Axes):
-            assert get_ylabel(plt_ax) == "estimated " + ylabel_mapping[functional]
-            assert get_title(plt_ax) == "Reliability Diagram"
+        assert get_ylabel(plt_ax) == "estimated " + ylabel_mapping[functional]
+        assert get_title(plt_ax) == "Reliability Diagram"
     else:
         assert (
             get_ylabel(plt_ax) == "prediction - estimated " + ylabel_mapping[functional]


### PR DESCRIPTION
Partially addresses #128.

This adds initial plotly support to `plot_reliability_diagram` (because it is one of the easier plot functions) via argument `plot_backend = "plotly"`.