### PR TITLE
CI make coverage account for full test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,8 @@ jobs:
       name: Build docs
       run: hatch run docs:build
 
-    - name: Run tests with coverage report
+    - if: matrix.python-version == '3.11' && runner.os == 'Linux'
+      name: Run tests with coverage report
       # run: hatch run cov --cov-report=xml
       # Run coverage with hatch test matrix and cov-append.
       run: |
@@ -58,11 +59,10 @@ jobs:
         hatch run test:cov --cov-report=xml
 
     - if: matrix.python-version == '3.11' && runner.os == 'Linux'
-      name: Upload coverage reports to Codecov
+      name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v3
       
-    - if: matrix.python-version == '3.11' && runner.os == 'Linux'
-      name: Run test matrix
+    - name: Run test matrix
       run: |
         hatch -e test run versions
         hatch -e test run pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,8 +49,12 @@ jobs:
       name: Build docs
       run: hatch run docs:build
 
-    - name: Run tests
-      run: hatch run cov --cov-report=xml
+    - name: Run tests with coverage report
+      # run: hatch run cov --cov-report=xml
+      # Run coverage with hatch test matrix and cov-append.
+      run: |
+        hatch run cov-erase
+        hatch run test:cov --cov-report=xml
 
     - if: matrix.python-version == '3.9' && runner.os == 'Linux'
       name: Upload coverage reports to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9']
+        # Switch back to macos-latest, once macos-14 has become macos-latest.
+        os: [ubuntu-latest, windows-latest, macos-14]
+        python-version: ['3.11']  # hatch env defines its own matrix with python versions
     env:
       # https://github.com/microsoft/azure-pipelines-tasks/issues/16426
       # https://github.com/orgs/community/discussions/26434
@@ -41,11 +42,11 @@ jobs:
       run: |
         pip install hatch
 
-    - if: matrix.python-version == '3.9' && runner.os == 'Linux'
+    - if: matrix.python-version == '3.11' && runner.os == 'Linux'
       name: Lint
       run: hatch run lint:all
 
-    - if: matrix.python-version == '3.9' && runner.os == 'Linux'
+    - if: matrix.python-version == '3.11' && runner.os == 'Linux'
       name: Build docs
       run: hatch run docs:build
 
@@ -56,11 +57,11 @@ jobs:
         hatch run cov-erase
         hatch run test:cov --cov-report=xml
 
-    - if: matrix.python-version == '3.9' && runner.os == 'Linux'
+    - if: matrix.python-version == '3.11' && runner.os == 'Linux'
       name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
       
-    - if: matrix.python-version == '3.9' && runner.os == 'Linux'
+    - if: matrix.python-version == '3.11' && runner.os == 'Linux'
       name: Run test matrix
       run: |
         hatch -e test run versions

--- a/dev_tools/print_package_versions.py
+++ b/dev_tools/print_package_versions.py
@@ -1,0 +1,10 @@
+from importlib.metadata import version
+from importlib.util import find_spec
+
+if __name__ == "__main__":
+    for m in ["numpy", "polars", "scipy", "pandas", "pyarrow"]:
+        # ruff: noqa: T201
+        if find_spec(m):
+            print(f"{m} {version(m)}")
+        else:
+            print(f"{m} not installed")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,9 @@ name."py3.11".set-extra-dependencies = [
 # To check correct versions, you can run
 # hatch -e test run pip freeze | grep polars
 [tool.hatch.envs.test.scripts]
-versions = ["pip freeze | grep -E 'numpy|polars|scipy|pandas|pyarrow'"]
+# versions = ["pip freeze | grep -E 'numpy|polars|scipy|pandas|pyarrow'"]
+# A version of 'versions' working on all plattforms, in particular Windows.
+versions = "python dev_tools/print_package_versions.py"
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=src/model_diagnostics --cov-append {args}"
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ dependencies = [
 [tool.hatch.envs.default.scripts]
 # Adding "-n auto" (pytest-xdist) allows parallel execution but swallows output.
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=src/model_diagnostics {args}"
+cov-erase = "coverage erase"
 no-cov = "cov --no-cov"
 
 [tool.hatch.envs.docs]
@@ -258,6 +259,7 @@ name."py3.11".set-extra-dependencies = [
 # hatch -e test run pip freeze | grep polars
 [tool.hatch.envs.test.scripts]
 versions = ["pip freeze | grep -E 'numpy|polars|scipy|pandas|pyarrow'"]
+cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=src/model_diagnostics --cov-append {args}"
 
 [tool.hatch.version]
 path = "src/model_diagnostics/__about__.py"

--- a/src/model_diagnostics/calibration/tests/test_identification.py
+++ b/src/model_diagnostics/calibration/tests/test_identification.py
@@ -233,7 +233,10 @@ def test_compute_bias_numerical_feature():
     )
     # With polars==0.19.19, to_numpy() returns polars.series._numpy.SeriesView instead
     # of numpy array. Therefore, we add the np.asarray().
-    bias = np.asarray((df.get_column("y_pred") - df.get_column("y_obs")).to_numpy())
+    # The Windows CI runner with python 3.10, polars 0.19.19 and numpy1.22.0 seems to
+    # have a bug in to_numpy, as bias[0] = 2.854484e-311 instead of 1. Therefore, we
+    # use to_list instead of to_numpy.
+    bias = np.asarray((df.get_column("y_pred") - df.get_column("y_obs")).to_list())
     df_expected = pl.DataFrame(
         {
             "feature": 0.045 + 0.1 * np.arange(10),

--- a/src/model_diagnostics/calibration/tests/test_identification.py
+++ b/src/model_diagnostics/calibration/tests/test_identification.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from functools import partial
 
 import numpy as np
@@ -235,26 +234,6 @@ def test_compute_bias_numerical_feature():
     # With polars==0.19.19, to_numpy() returns polars.series._numpy.SeriesView instead
     # of numpy array. Therefore, we add the np.asarray().
     bias = np.asarray((df.get_column("y_pred") - df.get_column("y_obs")).to_numpy())
-    assert df.schema == OrderedDict(
-        [("y_obs", pl.Float64), ("y_pred", pl.Float64), ("feature", pl.Float64)]
-    )
-    assert_series_equal(
-        (df.get_column("y_pred") - df.get_column("y_obs"))[:n_steps],
-        pl.Series(
-            "y_pred", [1.0, 0.99, 0.98, 0.97, 0.96, 0.95, 0.94, 0.93, 0.92, 0.91]
-        ),
-    )
-    assert n_steps == 10
-    assert np.sqrt(n_steps) == pytest.approx(3.1622776601683795)
-    np.testing.assert_allclose(
-        (df.get_column("y_pred") - df.get_column("y_obs")).to_numpy()[:n_steps],
-        [1.0, 0.99, 0.98, 0.97, 0.96, 0.95, 0.94, 0.93, 0.92, 0.91],
-    )
-    np.testing.assert_allclose(
-        bias[:n_steps],
-        [1.0, 0.99, 0.98, 0.97, 0.96, 0.95, 0.94, 0.93, 0.92, 0.91],
-    )
-    assert np.std(bias[:n_steps], ddof=1) == pytest.approx(0.030276503540974924)
     df_expected = pl.DataFrame(
         {
             "feature": 0.045 + 0.1 * np.arange(10),


### PR DESCRIPTION
So far, the CI coverage only took the test run of a single setting/matrix element. This PR makes it take into account the full test matrix. Therefore, the coverage percentage will increase - rightfully so.

Different test matrix entries just test different things due to packages being installed or not.