### PR TITLE
ENH add config and move plot_backend to config system

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Highlights:
 - Assess the predictive performance of models
     - strictly consistent, homogeneous [scoring functions](https://lorentzenchr.github.io/model-diagnostics/reference/model_diagnostics/scoring/scoring/)
     - [score decomposition](https://lorentzenchr.github.io/model-diagnostics/reference/model_diagnostics/scoring/scoring/#model_diagnostics.scoring.scoring.decompose) into miscalibration, discrimination and uncertainty
+- Choose your plot backend, either [matplotlib](https://matplotlib.org) or [plotly](https://plotly.com/python/), e.g., via [set_config](https://lorentzenchr.github.io/model-diagnostics/reference/model_diagnostics/#model_diagnostics.set_config).
 
 :rocket: To our knowledge, this is the first python package to offer reliability diagrams for quantiles and expectiles and a score decomposition, both made available by an internal implementation of isotonic quantile/expectile regression. :rocket:
 

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -11,6 +11,7 @@ for path in sorted(
     - set(Path("src").rglob("*tests/*.py"))
     - set(Path("src").rglob("_*/*.py"))
     - set(Path("src/").rglob("__about__.py"))
+    - set(Path("src").rglob("*_config.py"))
 ):
     module_path = path.relative_to("src").with_suffix("")
     doc_path = path.relative_to("src").with_suffix(".md")

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ Highlights:
 - Assess the predictive performance of models
     - strictly consistent, homogeneous [scoring functions][model_diagnostics.scoring.scoring]
     - [score decomposition][model_diagnostics.scoring.decompose] into miscalibration, discrimination and uncertainty
+- Choose your plot backend, either [matplotlib](https://matplotlib.org) or [plotly](https://plotly.com/python/), e.g., via [set_config][model_diagnostics.set_config].
 
 :rocket: To our knowledge, this is the first python package to offer reliability diagrams for quantiles and expectiles and a score decomposition, both made available by an internal implementation of isotonic quantile/expectile regression. :rocket:
 

--- a/src/model_diagnostics/__init__.py
+++ b/src/model_diagnostics/__init__.py
@@ -2,4 +2,12 @@ from importlib.metadata import version
 
 from packaging.version import parse
 
+from ._config import config_context, get_config, set_config
+
 polars_version = parse(version("polars"))
+
+__all__ = [
+    "get_config",
+    "set_config",
+    "config_context",
+]

--- a/src/model_diagnostics/_config.py
+++ b/src/model_diagnostics/_config.py
@@ -1,0 +1,119 @@
+"""
+Global configuration state and functions for management
+To a large part taken from scikit-learn.
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from importlib.util import find_spec
+from typing import Optional
+
+_global_config = {
+    "plot_backend": "matplotlib",
+}
+
+
+def get_config() -> dict:
+    """Retrieve current values for configuration set by :func:`set_config`.
+
+    Returns
+    -------
+    config : dict
+        A copy of the configuration dictionary. Keys are parameter names that can be
+        passed to :func:`set_config`.
+
+    See Also
+    --------
+    config_context : Context manager for global model-diagnostics configuration.
+    set_config : Set global model-diagnostics configuration.
+
+    Examples
+    --------
+    >>> import model_diagnostics
+    >>> config = model_diagnostics.get_config()
+    >>> config.keys()
+    dict_keys([...])
+    """
+    # Return a copy of the global config so that users will
+    # not be able to modify the configuration with the returned dict.
+    return _global_config.copy()
+
+
+def set_config(
+    plot_backend: Optional[str] = None,
+) -> None:
+    """Set global model-diagnostics configuration.
+
+    Parameters
+    ----------
+    plot_backend : bool, default=None
+        The library used for plotting. Can be "matplotlib" or "plotly".
+        If None, the existing value won't change. Global default: "matplotlib".
+
+    See Also
+    --------
+    config_context : Context manager for global scikit-learn configuration.
+    get_config : Retrieve current values of the global configuration.
+
+    Examples
+    --------
+    >>> from model_diagnostics import set_config
+    >>> set_config(plot_backend="plotly")  # doctest: +SKIP
+    """
+    if plot_backend not in (None, "matplotlib", "plotly"):
+        msg = f"The plot_backend must be matplotlib or plotly, got {plot_backend}."
+        raise ValueError(msg)
+    if plot_backend == "plotly" and not find_spec("plotly"):
+        msg = (
+            "In order to set the plot backend to plotly, plotly must be installed, "
+            "i.e. via `pip install plotly`."
+        )
+        raise ModuleNotFoundError(msg)
+
+    if plot_backend is not None:
+        _global_config["plot_backend"] = plot_backend
+
+
+@contextmanager
+def config_context(
+    *,
+    plot_backend: Optional[str] = None,
+) -> Iterator[None]:
+    """Context manager for global model-diagnostics configuration.
+
+    Parameters
+    ----------
+    plot_backend : bool, default=None
+        The library used for plotting. Can be "matplotlib" or "plotly".
+        If None, the existing value won't change. Global default: "matplotlib".
+
+    Yields
+    ------
+    None.
+
+    See Also
+    --------
+    set_config : Set global model-diagnostics configuration.
+    get_config : Retrieve current values of the global configuration.
+
+    Notes
+    -----
+    All settings, not just those presently modified, will be returned to
+    their previous values when the context manager is exited.
+
+    Examples
+    --------
+    >>> import model_diagnostics
+    >>> from model_diagnostics.calibration import plot_reliability_diagram
+    >>> with model_diagnostics.config_context(plot_backend="plotly"):  # doctest: +SKIP
+    ...    plot_reliability_diagram(y_obs=[0, 1], y_pred=[0.3, 0.7])
+    """
+    old_config = get_config()
+    set_config(
+        plot_backend=plot_backend,
+    )
+
+    try:
+        yield
+    finally:
+        set_config(**old_config)

--- a/src/model_diagnostics/_utils/plot_helper.py
+++ b/src/model_diagnostics/_utils/plot_helper.py
@@ -4,17 +4,13 @@ import matplotlib as mpl
 
 
 def get_plotly_color(i):
-    try:
-        sys.modules["plotly"]
-        # Sometimes, those turn out to be the same as matplotlib default.
-        # colors = plotly.colors.DEFAULT_PLOTLY_COLORS
-        # Those are the plotly color default color palette in hex.
-        import plotly.express as px
+    # Sometimes, those turn out to be the same as matplotlib default.
+    # colors = plotly.colors.DEFAULT_PLOTLY_COLORS
+    # Those are the plotly color default color palette in hex.
+    import plotly.express as px
 
-        colors = px.colors.qualitative.Plotly
-        return colors[i % len(colors)]
-    except KeyError:
-        return False
+    colors = px.colors.qualitative.Plotly
+    return colors[i % len(colors)]
 
 
 def get_xlabel(ax):

--- a/src/model_diagnostics/calibration/identification.py
+++ b/src/model_diagnostics/calibration/identification.py
@@ -45,7 +45,6 @@ def identification_function(
         - `"median"`. Argument `level` is neglected.
         - `"expectile"`
         - `"quantile"`
-
     level : float
         The level of the expectile of quantile. (Often called \(\alpha\).)
         It must be `0 < level < 1`.
@@ -162,7 +161,6 @@ def compute_bias(
         - `"median"`. Argument `level` is neglected.
         - `"expectile"`
         - `"quantile"`
-
     level : float
         The level of the expectile of quantile. (Often called \(\alpha\).)
         It must be `0 < level < 1`.

--- a/src/model_diagnostics/calibration/plots.py
+++ b/src/model_diagnostics/calibration/plots.py
@@ -12,7 +12,7 @@ from scipy import special
 from scipy.stats import bootstrap
 from sklearn.isotonic import IsotonicRegression as IsotonicRegression_skl
 
-from model_diagnostics import polars_version
+from model_diagnostics import get_config, polars_version
 from model_diagnostics._utils._array import (
     array_name,
     get_array_min_max,
@@ -37,7 +37,6 @@ def plot_reliability_diagram(
     confidence_level: float = 0.9,
     diagram_type: str = "reliability",
     ax: Optional[mpl.axes.Axes] = None,
-    plot_backend: str = "matplotlib",
 ):
     r"""Plot a reliability diagram.
 
@@ -82,16 +81,12 @@ def plot_reliability_diagram(
 
     ax : matplotlib.axes.Axes or plotly Figure
         Axes object to draw the plot onto, otherwise uses the current Axes.
-    plot_backend: str
-        The plotting backend to use when `ax = None`. Options are:
-
-        - "matplotlib"
-        - "plotly"
 
     Returns
     -------
     ax :
-        Either the matplotlib axes or the plotly figure.
+        Either the matplotlib axes or the plotly figure. This is configurable via
+        `model_diagnostics.set_config` and `model_diagnostics.config_context`.
 
     Notes
     -----
@@ -115,11 +110,8 @@ def plot_reliability_diagram(
         In: Proceedings of the National Academy of Sciences 118.8 (2021), e2016191118.
         [doi:10.1073/pnas.2016191118](https://doi.org/10.1073/pnas.2016191118).
     """
-    if plot_backend not in ("matplotlib", "plotly"):
-        msg = f"The plot_backend must be matplotlib or plotly, got {plot_backend}."
-        raise ValueError(msg)
-
     if ax is None:
+        plot_backend = get_config()["plot_backend"]
         if plot_backend == "matplotlib":
             ax = plt.gca()
         else:
@@ -374,15 +366,12 @@ def plot_bias(
         fulfil `0 <= confidence_level < 1`.
     ax : matplotlib.axes.Axes or plotly Figure
         Axes object to draw the plot onto, otherwise uses the current Axes.
-    plot_backend: str
-        The plotting backend to use when `ax = None`. Options are:
-
-        - "matplotlib"
-        - "plotly"
 
     Returns
     -------
-    ax
+    ax :
+        Either the matplotlib axes or the plotly figure. This is configurable via
+        `model_diagnostics.set_config` and `model_diagnostics.config_context`.
 
     Notes
     -----
@@ -406,10 +395,8 @@ def plot_bias(
         raise ValueError(msg)
     with_errorbars = confidence_level > 0
 
-    if plot_backend not in ("matplotlib", "plotly"):
-        msg = f"The plot_backend must be matplotlib or plotly, got {plot_backend}."
-        raise ValueError(msg)
     if ax is None:
+        plot_backend = get_config()["plot_backend"]
         if plot_backend == "matplotlib":
             ax = plt.gca()
         else:

--- a/src/model_diagnostics/calibration/plots.py
+++ b/src/model_diagnostics/calibration/plots.py
@@ -63,7 +63,6 @@ def plot_reliability_diagram(
         - `"median"`. Argument `level` is neglected.
         - `"expectile"`
         - `"quantile"`
-
     level : float
         The level of the expectile or quantile. (Often called \(\alpha\).)
         It must be `0 <= level <= 1`.
@@ -78,15 +77,16 @@ def plot_reliability_diagram(
         - `"reliability"`: Plot a reliability diagram.
         - `"bias"`: Plot roughly a 45 degree rotated reliability diagram. The resulting
           plot is similar to `plot_bias`, i.e. `y_pred - E(y_obs|y_pred)` vs `y_pred`.
-
     ax : matplotlib.axes.Axes or plotly Figure
         Axes object to draw the plot onto, otherwise uses the current Axes.
 
     Returns
     -------
     ax :
-        Either the matplotlib axes or the plotly figure. This is configurable via
-        `model_diagnostics.set_config` and `model_diagnostics.config_context`.
+        Either the matplotlib axes or the plotly figure. This is configurable by
+        setting the `plot_backend` via
+        [`model_diagnostics.set_config`][model_diagnostics.set_config] or
+        [`model_diagnostics.config_context`][model_diagnostics.config_context].
 
     Notes
     -----
@@ -351,7 +351,6 @@ def plot_bias(
         - `"median"`. Argument `level` is neglected.
         - `"expectile"`
         - `"quantile"`
-
     level : float
         The level of the expectile or quantile. (Often called \(\alpha\).)
         It must be `0 <= level <= 1`.
@@ -370,8 +369,10 @@ def plot_bias(
     Returns
     -------
     ax :
-        Either the matplotlib axes or the plotly figure. This is configurable via
-        `model_diagnostics.set_config` and `model_diagnostics.config_context`.
+        Either the matplotlib axes or the plotly figure. This is configurable by
+        setting the `plot_backend` via
+        [`model_diagnostics.set_config`][model_diagnostics.set_config] or
+        [`model_diagnostics.config_context`][model_diagnostics.config_context].
 
     Notes
     -----

--- a/src/model_diagnostics/scoring/plots.py
+++ b/src/model_diagnostics/scoring/plots.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 
+from model_diagnostics import get_config
 from model_diagnostics._utils._array import (
     get_array_min_max,
     get_second_dimension,
@@ -26,7 +27,6 @@ def plot_murphy_diagram(
     functional: str = "mean",
     level: float = 0.5,
     ax: Optional[mpl.axes.Axes] = None,
-    plot_backend: str = "matplotlib",
 ):
     r"""Plot a Murphy diagram.
 
@@ -63,15 +63,12 @@ def plot_murphy_diagram(
         `level=0.5` and `functional="quantile"` gives the median.
     ax : matplotlib.axes.Axes
         Axes object to draw the plot onto, otherwise uses the current Axes.
-    plot_backend: str
-        The plotting backend to use when `ax = None`. Options are:
-
-        - "matplotlib"
-        - "plotly"
 
     Returns
     -------
-    ax
+    ax :
+        Either the matplotlib axes or the plotly figure. This is configurable via
+        `model_diagnostics.set_config` and `model_diagnostics.config_context`.
 
     Notes
     -----
@@ -86,11 +83,8 @@ def plot_murphy_diagram(
         Representations, and Forecast Rankings".
         [arxiv:1503.08195](https://arxiv.org/abs/1503.08195).
     """
-    if plot_backend not in ("matplotlib", "plotly"):
-        msg = f"The plot_backend must be matplotlib or plotly, got {plot_backend}."
-        raise ValueError(msg)
-
     if ax is None:
+        plot_backend = get_config()["plot_backend"]
         if plot_backend == "matplotlib":
             ax = plt.gca()
         else:

--- a/src/model_diagnostics/scoring/plots.py
+++ b/src/model_diagnostics/scoring/plots.py
@@ -55,7 +55,6 @@ def plot_murphy_diagram(
         - `"median"`. Argument `level` is neglected.
         - `"expectile"`
         - `"quantile"`
-
     level : float
         The level of the expectile of quantile. (Often called \(\alpha\).)
         It must be `0 < level < 1`.
@@ -67,8 +66,10 @@ def plot_murphy_diagram(
     Returns
     -------
     ax :
-        Either the matplotlib axes or the plotly figure. This is configurable via
-        `model_diagnostics.set_config` and `model_diagnostics.config_context`.
+        Either the matplotlib axes or the plotly figure. This is configurable by
+        setting the `plot_backend` via
+        [`model_diagnostics.set_config`][model_diagnostics.set_config] or
+        [`model_diagnostics.config_context`][model_diagnostics.config_context].
 
     Notes
     -----

--- a/src/model_diagnostics/scoring/scoring.py
+++ b/src/model_diagnostics/scoring/scoring.py
@@ -595,7 +595,6 @@ class ElementaryScore(_BaseScoringFunction):
         - `"median"`. Argument `level` is neglected.
         - `"expectile"`
         - `"quantile"`
-
     level : float
         The level of the expectile of quantile. (Often called \(\alpha\).)
         It must be `0 < level < 1`.
@@ -729,7 +728,6 @@ def decompose(
         - `"median"`. Argument `level` is neglected.
         - `"expectile"`
         - `"quantile"`
-
     level : float or None
         Functionals like expectiles and quantiles have a level (often called alpha).
         If `None`, then it will be inferred from `scoring_function.level`.

--- a/src/model_diagnostics/scoring/tests/test_plots.py
+++ b/src/model_diagnostics/scoring/tests/test_plots.py
@@ -6,6 +6,7 @@ from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 
+from model_diagnostics import config_context
 from model_diagnostics._utils.plot_helper import (
     get_legend_list,
     get_title,
@@ -29,7 +30,6 @@ from model_diagnostics.scoring import plot_murphy_diagram
             "XXX",
             "The ax argument must be None, a matplotlib Axes or a plotly Figure",
         ),
-        ("plot_backend", "XXX", "The plot_backend must be"),
     ],
 )
 def test_plot_murphy_diagram_raises(param, value, msg):
@@ -83,16 +83,16 @@ def test_plot_murphy_diagram(functional, level, etas, weights, ax, plot_backend)
     clf = LogisticRegression(solver="newton-cholesky")
     clf.fit(X_train, y_train, w_train)
     y_pred = clf.predict_proba(X_test)[:, 1]
-    plt_ax = plot_murphy_diagram(
-        y_obs=y_test,
-        y_pred=y_pred,
-        weights=w_test,
-        etas=etas,
-        functional=functional,
-        level=level,
-        ax=ax,
-        plot_backend=plot_backend,
-    )
+    with config_context(plot_backend=plot_backend):
+        plt_ax = plot_murphy_diagram(
+            y_obs=y_test,
+            y_pred=y_pred,
+            weights=w_test,
+            etas=etas,
+            functional=functional,
+            level=level,
+            ax=ax,
+        )
 
     if ax is not None:
         assert ax is plt_ax
@@ -101,16 +101,16 @@ def test_plot_murphy_diagram(functional, level, etas, weights, ax, plot_backend)
     assert get_ylabel(plt_ax) == "score"
     assert get_title(plt_ax) == "Murphy Diagram"
 
-    plt_ax = plot_murphy_diagram(
-        y_obs=y_test,
-        y_pred=pl.Series(values=y_pred, name="simple"),
-        weights=w_test,
-        etas=etas,
-        functional=functional,
-        level=level,
-        ax=ax,
-        plot_backend=plot_backend,
-    )
+    with config_context(plot_backend=plot_backend):
+        plt_ax = plot_murphy_diagram(
+            y_obs=y_test,
+            y_pred=pl.Series(values=y_pred, name="simple"),
+            weights=w_test,
+            etas=etas,
+            functional=functional,
+            level=level,
+            ax=ax,
+        )
     assert get_title(plt_ax) == "Murphy Diagram simple"
 
 
@@ -125,12 +125,12 @@ def test_plot_murphy_diagram_multiple_predictions(plot_backend):
     y_obs[::2] = 0
     y_pred = pl.DataFrame({"model_2": np.ones(n_obs), "model_1": 3 * np.ones(n_obs)})
     fig, ax = plt.subplots()
-    plt_ax = plot_murphy_diagram(
-        y_obs=y_obs,
-        y_pred=y_pred,
-        ax=ax,
-        plot_backend=plot_backend,
-    )
+    with config_context(plot_backend=plot_backend):
+        plt_ax = plot_murphy_diagram(
+            y_obs=y_obs,
+            y_pred=y_pred,
+            ax=ax,
+        )
     assert get_title(plt_ax) == "Murphy Diagram"
     legend_text = get_legend_list(plt_ax)
     assert len(legend_text) == 2

--- a/src/model_diagnostics/tests/test_config.py
+++ b/src/model_diagnostics/tests/test_config.py
@@ -1,0 +1,61 @@
+import pytest
+
+from model_diagnostics import config_context, get_config, set_config
+
+
+@pytest.mark.parametrize(
+    ("param", "value", "msg"),
+    [
+        ("plot_backend", "XXX", "The plot_backend must be"),
+    ],
+)
+def test_set_config_raises(param, value, msg):
+    """Test that set_config raises errors."""
+    with pytest.raises(ValueError, match=msg):
+        set_config(**{param: value})
+
+
+def test_config_context():
+    # Default value.
+    assert get_config() == {"plot_backend": "matplotlib"}
+
+    pytest.importorskip("plotly")
+
+    # Not using as a context manager affects nothing
+    config_context(plot_backend="plotly")
+    assert get_config()["plot_backend"] == "matplotlib"
+
+    with config_context(plot_backend="plotly"):
+        assert get_config() == {"plot_backend": "plotly"}
+    assert get_config()["plot_backend"] == "matplotlib"
+
+    with config_context(plot_backend="plotly"):
+        with config_context(plot_backend=None):
+            assert get_config()["plot_backend"] == "plotly"
+
+        assert get_config()["plot_backend"] == "plotly"
+
+        with config_context(plot_backend="matplotlib"):
+            assert get_config()["plot_backend"] == "matplotlib"
+
+            with config_context(plot_backend=None):
+                assert get_config()["plot_backend"] == "matplotlib"
+
+                # global setting will not be retained outside of context that
+                # did not modify this setting
+                set_config(plot_backend="plotly")
+                assert get_config()["plot_backend"] == "plotly"
+
+            assert get_config()["plot_backend"] == "matplotlib"
+
+        assert get_config()["plot_backend"] == "plotly"
+
+    assert get_config() == {"plot_backend": "matplotlib"}
+
+    # No positional arguments
+    with pytest.raises(TypeError):
+        config_context(True)  # ruff: noqa: FBT003
+
+    # No unknown arguments
+    with pytest.raises(TypeError):
+        config_context(do_something_else=True).__enter__()

--- a/src/model_diagnostics/tests/test_config.py
+++ b/src/model_diagnostics/tests/test_config.py
@@ -1,3 +1,5 @@
+from importlib.util import find_spec
+
 import pytest
 
 from model_diagnostics import config_context, get_config, set_config
@@ -13,6 +15,14 @@ def test_set_config_raises(param, value, msg):
     """Test that set_config raises errors."""
     with pytest.raises(ValueError, match=msg):
         set_config(**{param: value})
+
+
+def test_set_config_raises_plotly_not_installed():
+    if find_spec("plotly"):
+        pytest.skip("This test can only work if plotly is NOT installed.")
+    msg = "In order to set the plot backend to plotly, plotly must be installed"
+    with pytest.raises(ModuleNotFoundError, match=msg):
+        set_config(plot_backend="plotly")
 
 
 def test_config_context():


### PR DESCRIPTION
Closes #128.
This adds a config system, either globally via `set_config(plot_backend=...)` or via context manager `config_context(plot_backend=...)`.
Therefore, the `plot_backend` parameter of the plot_* functions is removed.