### PR TITLE
FIX polars 0.20.20 lazy neglects head(0)

### DIFF
--- a/src/model_diagnostics/calibration/identification.py
+++ b/src/model_diagnostics/calibration/identification.py
@@ -466,8 +466,15 @@ def compute_bias(
                     )
                     .sort("__priority", descending=True)
                     .head(n_bins)
-                    .sort(feature_name, descending=False)
                 )
+                # FIXME: When n_bins=0, the resut should be an empty dataframe
+                # (0 rows and some columns). For some unknown reason as of
+                # polars 0.20.20, the following sort neglects the head(0) statement.
+                # Therefore, we place an explicit collect here. This should not be
+                # needed!
+                if n_bins == 0 or feature.null_count() >= 1:
+                    df = df.collect().lazy()
+                df = df.sort(feature_name, descending=False)
 
                 df = df.select(
                     [


### PR DESCRIPTION
For some unknown reason, as of polars version 0.20.20, a LazyFrame neglects a `head(0)` statement if a `sort(..)` follows.