### PR TITLE
FIX safe_index_rows in windows

### DIFF
--- a/src/model_diagnostics/_utils/array.py
+++ b/src/model_diagnostics/_utils/array.py
@@ -296,7 +296,7 @@ def safe_index_rows(x, indices):
     """
     index = np.asarray(indices)
     if index.dtype.kind not in ("i", "u"):
-        msg = "Only integer indives are allowed for indexing rows."
+        msg = "Only integer indices are allowed for indexing rows."
         raise ValueError(msg)
 
     if is_pyarrow_table(x) or is_pyarrow_array(x):

--- a/src/model_diagnostics/_utils/tests/test_array.py
+++ b/src/model_diagnostics/_utils/tests/test_array.py
@@ -310,7 +310,7 @@ def test_get_sorted_array_names():
 
 def test_safe_index_rows_raises():
     """Test that safe_index_rows raises errors."""
-    msg = "Only integer indives are allowed for indexing rows."
+    msg = "Only integer indices are allowed for indexing rows."
     with pytest.raises(ValueError, match=msg):
         safe_index_rows(np.arange(2), "asd")
 

--- a/src/model_diagnostics/_utils/tests/test_array.py
+++ b/src/model_diagnostics/_utils/tests/test_array.py
@@ -336,6 +336,10 @@ def test_safe_index_rows(a):
     if isinstance(a, SkipContainer):
         pytest.skip("Module for data container not imported.")
 
+    # ruff: noqa: T201
+    print(f"{type(a)=}")
+    print(f"{a=}")
+
     a_sub = safe_index_rows(a, [0, 2])
 
     if is_pyarrow_table(a):


### PR DESCRIPTION
The following test failure on windows:
```
Run hatch -e test run versions
...
--------------------------------- test.py3.10 ---------------------------------
Creating environment: test.py3.10
Installing project in development mode
Checking dependencies
Syncing dependencies
numpy 1.22.0
polars 0.19.19
scipy 1.10.0
pandas not installed
pyarrow not installed
...
--------------------------------- test.py3.10 ---------------------------------
...
================================== FAILURES ===================================
__________________________ test_safe_index_rows[a9] ___________________________

a = array([-99,   1,  22], dtype=int64)

    @pytest.mark.parametrize(
        "a",
        [
            (-99, 1, 22),
            [-99, 1, 22],
            [[-99, 0], [1, 1], [22, 2]],
            np.array([-99, 1, 22]),
            np.array([[-99, 0], [1, 1], [22, 2]]),
            pa_array([-99, 1, 22]),
            pa_table({"0": [-99, 1, 22], "1": [0, 1, 2]}),
            pd_Series([-99, 1, 22]),
            pd_DataFrame({"0": [-99, 1, 22], "1": [0, 1, 2]}),
            pl.Series([-99, 1, 22]),
            pl.DataFrame({"0": [-99, 1, 22], "1": [0, 1, 2]}),
        ],
    )
    def test_safe_index_rows(a):
        """Test that safe_index_rows does its job."""
        if isinstance(a, SkipContainer):
            pytest.skip("Module for data container not imported.")
    
        # ruff: noqa: T201
        print(f"{type(a)=}")
        print(f"{a=}")
    
        a_sub = safe_index_rows(a, [0, 2])
    
        if is_pyarrow_table(a):
            # Because pyarrow has not to_numpy() and older versions of pyarrow
            # give the transposed with np.asarray(a)
            a = a.to_pandas()
            a_sub = a_sub.to_pandas()
        a = np.asarray(a)
        a_sub = np.asarray(a_sub)
    
        if length_of_second_dimension(a) >= 1:
            assert_array_equal(a_sub, np.array([[-99, 0], [22, 2]]))
        else:
>           assert_array_equal(a_sub, np.array([-99, 22]))
E           AssertionError: 
E           Arrays are not equal
E           
E           Mismatched elements: 1 / 2 (50%)
E           Max absolute difference: 2906183700195
E           Max relative difference: 2.93553909e+10
E            x: array([2906183700096,            22], dtype=int64)
E            y: array([-99,  22])

src\model_diagnostics\_utils\tests\test_array.py:356: AssertionError
---------------------------- Captured stdout call -----------------------------
type(a)=<class 'polars.series.series.Series'>
a=shape: (3,)
Series: '' [i64]
[
	-99
	1
	22
]
```