### PR TITLE
CI add pyathon 3.12 and fix pandas without pyarrow installed

### DIFF
--- a/.github/workflows/test_scheduled.yml
+++ b/.github/workflows/test_scheduled.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9']
+        python-version: ['3.11']  # hatch env defines its own matrix with python versions
     env:
       # https://github.com/microsoft/azure-pipelines-tasks/issues/16426
       # https://github.com/orgs/community/discussions/26434
@@ -40,15 +40,15 @@ jobs:
       run: |
         pip install hatch
 
-    - if: matrix.python-version == '3.9' && runner.os == 'Linux'
+    - if: matrix.python-version == '3.11' && runner.os == 'Linux'
       name: Formatter & Linter
       run: hatch run format:check
 
-    - if: matrix.python-version == '3.9' && runner.os == 'Linux'
+    - if: matrix.python-version == '3.11' && runner.os == 'Linux'
       name: Build docs
       run: hatch run docs:build
 
-    - if: matrix.python-version == '3.9' && runner.os == 'Linux'
+    - if: matrix.python-version == '3.11' && runner.os == 'Linux'
       name: Run test matrix
       run: |
         hatch -e test run versions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,7 +259,7 @@ name."py3.10".set-extra-dependencies = [
   "polars==1.0.0",
   "scipy==1.10",
 ]
-# Some intermediate versions
+# Some intermediate versions, with pandads but without pyarrow
 name."py3.11".set-extra-dependencies = [
   "numpy==1.26.*",
   "polars==1.0.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,7 +241,7 @@ dependencies = [
 ]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.9", "3.10", "3.11"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.test.overrides]
 # Minimal versions (partially inherited from scikit-learn 1.2.0)
@@ -259,8 +259,16 @@ name."py3.10".set-extra-dependencies = [
   "polars==1.0.0",
   "scipy==1.10",
 ]
-# latest versions, with plotly
+# Some intermediate versions
 name."py3.11".set-extra-dependencies = [
+  "numpy==1.26.*",
+  "polars==1.0.*",
+  "scipy==1.12.*",
+  "pandas==2.0.*",
+  "plotly",
+]
+# Latest versions, with plotly
+name."py3.12".set-extra-dependencies = [
   "numpy>=2.0.0",
   "polars>=1.4.1",
   "scipy",

--- a/src/model_diagnostics/_utils/array.py
+++ b/src/model_diagnostics/_utils/array.py
@@ -170,6 +170,15 @@ def get_sorted_array_names(y_pred: Union[npt.ArrayLike, pl.Series, pl.DataFrame]
     return pred_names, sorted_indices
 
 
+def is_pandas_series(x):
+    """Return True if the x is a pandas Series."""
+    try:
+        pd = sys.modules["pandas"]
+    except KeyError:
+        return False
+    return isinstance(x, pd.Series)
+
+
 def is_pandas_df(x):
     """Return True if the x is a pandas DataFrame."""
     try:

--- a/src/model_diagnostics/_utils/array.py
+++ b/src/model_diagnostics/_utils/array.py
@@ -291,13 +291,6 @@ def safe_assign_column(x, values, column_index):
                     warnings.filterwarnings(
                         "ignore", category=DeprecationWarning, message=msg
                     )
-                    msg = (
-                        "reindexing with a non-unique Index is deprecated and will "
-                        "raise in a future version."
-                    )
-                    warnings.filterwarnings(
-                        "ignore", category=FutureWarning, message=msg
-                    )
                     if not x.index.is_unique:
                         # Pandas might error with:
                         #   cannot reindex on an axis with duplicate labels

--- a/src/model_diagnostics/_utils/array.py
+++ b/src/model_diagnostics/_utils/array.py
@@ -256,50 +256,58 @@ def safe_assign_column(x, values, column_index):
             row[column_index] = values[i]
             x[i] = row
     elif is_pandas_df(x):
-        # Possible fix for older versions
-        # if isinstance(values, pl.Series):
-        #     pd = sys.modules["pandas"]
-        #     values = pd.api.interchange.from_dataframe(
-        #               pl.DataFrame(values)).iloc[:, 0]
         try:
             # Avoid deprecation warning of pandas by handling dtype explicitly.
             #   Setting an item of incompatible dtype is deprecated and will raise in a
             #   future error of pandas.
+            # Also, assigning with a different index makes troubles.
             pd = sys.modules["pandas"]
             dtype = x.dtypes.iloc[column_index]
-            if parse(version("pandas")) < Version("2.0.0") and isinstance(
-                dtype, pd.CategoricalDtype
+            if isinstance(values, pl.Series) and isinstance(
+                values.dtype, pl.Categorical
             ):
+                # FIXME: pyarrow not installed
+                pd_values = pd.Series(
+                    data=values.cast(pl.Utf8).to_numpy(),
+                    dtype=dtype,
+                )
+            else:
+                pd_values = pd.Series(
+                    data=values.to_pandas()
+                    if isinstance(values, pl.Series)
+                    else values,
+                    dtype=dtype,
+                )
+            if parse(version("pandas")) < Version("2.0.0"):
                 # FIXME: pandas >= 2.0 (<2.0 means 1.5.*)
-                # We the following DeprecationWarning of pandas:
-                #   In a future version, `df.iloc[:, i] = newvals` will attempt to set
-                #   the values inplace instead of always setting a new array. To retain
-                #   the old behavior, use either `df[df.columns[i]] = newvals` or, if
-                #   columns are non-unique, `df.isetitem(i, newvals)`
                 with warnings.catch_warnings():
                     msg = (
                         r"In a future version, `df.iloc\[:, i\] = newvals` will "
                         r"attempt to set the values inplace instead of always "
-                        r"setting a new array"
+                        r"setting a new array. To retain the old behavior, use either "
+                        r"`df\[df.columns\[i\]\] = newvals` or, if columns are "
+                        r"non-unique, `df.isetitem\(i, newvals\)`"
                     )
                     warnings.filterwarnings(
                         "ignore", category=DeprecationWarning, message=msg
                     )
-                    x.iloc[:, column_index] = pd.Series(
-                        data=(
-                            values.to_pandas()
-                            if isinstance(values, pl.Series)
-                            else values
-                        ),
-                        dtype=dtype,
+                    msg = (
+                        "reindexing with a non-unique Index is deprecated and will "
+                        "raise in a future version."
                     )
+                    warnings.filterwarnings(
+                        "ignore", category=FutureWarning, message=msg
+                    )
+                    if not x.index.is_unique:
+                        # Pandas might error with:
+                        #   cannot reindex on an axis with duplicate labels
+                        # Try reindexing ourselves.
+                        x = x.reset_index()
+                    if not pd_values.index.is_unique:
+                        pd_values = pd_values.reset_index()
+                    x.iloc[:, column_index] = pd_values
             else:
-                x.iloc[:, column_index] = pd.Series(
-                    data=(
-                        values.to_pandas() if isinstance(values, pl.Series) else values
-                    ),
-                    dtype=dtype,
-                )
+                x.iloc[:, column_index] = pd_values
         except Exception as e:
             # FIXME: pyarrow version XXX
             # Older pyarrow versions of AttributeError do not have a 'add_note' method.

--- a/src/model_diagnostics/_utils/binning.py
+++ b/src/model_diagnostics/_utils/binning.py
@@ -94,9 +94,10 @@ def bin_feature(
             # passed, e.g. with CategoricalDtype.
             if is_pandas_series(feature):
                 pandas = sys.modules["pandas"]
-                is_pandas_categorical = pandas.api.types.is_categorical_dtype(feature)
-                # dataframe = feature.to_frame(name="0").__dataframe__()
-                # feature = pl.from_dataframe(dataframe)[:, 0]
+                is_pandas_categorical = isinstance(
+                    feature.dtype,  # type: ignore
+                    pandas.CategoricalDtype,
+                )
                 feature = pl.from_dataframe(feature.to_frame(name="0"))[:, 0]  # type: ignore
                 if is_pandas_categorical and isinstance(feature.dtype, pl.Enum):
                     # Pandas categoricals usually get mapped to polars categoricals.


### PR DESCRIPTION
This adds python 3.12 to the test matrix. It also adds an environment with pandas installed, but pyarrow not installed. This shows some errors in the code that are fixed.