### PR TITLE
ENH allow y_obs and y_pred in plot_marginal to be None.

### DIFF
--- a/src/model_diagnostics/calibration/plots.py
+++ b/src/model_diagnostics/calibration/plots.py
@@ -765,6 +765,17 @@ def plot_marginal(
         [`model_diagnostics.set_config`][model_diagnostics.set_config] or
         [`model_diagnostics.config_context`][model_diagnostics.config_context].
     """
+    plot_items = ["y_obs_mean", "y_pred_mean"]
+
+    if y_obs is None:
+        y_obs = np.empty(X.shape[0])
+        y_obs.fill(0)
+        plot_items.remove("y_obs_mean")
+    if y_pred is None:
+        y_pred = np.empty(X.shape[0])
+        y_pred.fill(0)
+        plot_items.remove("y_pred_mean")
+
     if ax is None:
         plot_backend = get_config()["plot_backend"]
         if plot_backend == "matplotlib":
@@ -978,7 +989,6 @@ def plot_marginal(
                 showlegend=False,
             )
 
-    plot_items = ["y_obs_mean", "y_pred_mean"]
     if predict_function is not None:
         plot_items.append("partial_dependence")
     label_dict = {


### PR DESCRIPTION
This MR fixes #178 .
If either y_obs or y_pred are None default to zero vectors and drop y_obs/pred_mean from plot_items.
This leads to the expected result that in the marginal plot either y_obs or y_pred (or both) can be omitted.