### PR TITLE
ENH add show_lines to plot_marginal

### DIFF
--- a/src/model_diagnostics/calibration/plots.py
+++ b/src/model_diagnostics/calibration/plots.py
@@ -712,7 +712,7 @@ def plot_marginal(
     n_max: int = 1000,
     rng: Optional[Union[np.random.Generator, int]] = None,
     ax: Optional[mpl.axes.Axes] = None,
-    show_lines: str = "auto",
+    show_lines: str = "numerical",
 ):
     """Plot marginal observed and predicted conditional on a feature.
 
@@ -760,9 +760,9 @@ def plot_marginal(
     show_lines : str
         Option for how to display mean values and partial dependence:
 
-        - "auto": String and categorical features are drawn as points, numerical ones
-          as lines.
-        - "all": All types of features are drawn as lines.
+        - "always": Always draw lines.
+        - "numerical": String and categorical features are drawn as points, numerical
+          ones as lines.
 
     Returns
     -------
@@ -824,8 +824,10 @@ def plot_marginal(
         )
         raise ValueError(msg)
 
-    if show_lines not in ("all", "auto"):
-        msg = f"The argument show_lines mut be 'all' or 'auto'; got {show_lines}."
+    if show_lines not in ("always", "numerical"):
+        msg = (
+            f"The argument show_lines mut be 'always' or 'numerical'; got {show_lines}."
+        )
         raise ValueError(msg)
 
     # estimator = getattr(predict_callable, "__self__", None)
@@ -1014,7 +1016,7 @@ def plot_marginal(
                     x,
                     df_no_nulls[m],
                     marker="o",
-                    linestyle="None" if show_lines == "auto" else linestyle,
+                    linestyle="None" if show_lines == "numerical" else linestyle,
                     label=label,
                 )
             else:
@@ -1022,8 +1024,8 @@ def plot_marginal(
                     x=x,
                     y=df_no_nulls[m],
                     marker={"color": get_plotly_color(i)},
-                    mode="markers" if show_lines == "auto" else "lines+markers",
-                    line=None if show_lines == "auto" else line,
+                    mode="markers" if show_lines == "numerical" else "lines+markers",
+                    line=None if show_lines == "numerical" else line,
                     name=label,
                     secondary_y=True,
                 )

--- a/src/model_diagnostics/calibration/plots.py
+++ b/src/model_diagnostics/calibration/plots.py
@@ -712,6 +712,7 @@ def plot_marginal(
     n_max: int = 1000,
     rng: Optional[Union[np.random.Generator, int]] = None,
     ax: Optional[mpl.axes.Axes] = None,
+    show_lines: str = "auto",
 ):
     """Plot marginal observed and predicted conditional on a feature.
 
@@ -756,6 +757,12 @@ def plot_marginal(
         `np.random.default_rng(rng)`.
     ax : matplotlib.axes.Axes or plotly Figure
         Axes object to draw the plot onto, otherwise uses the current Axes.
+    show_lines : str
+        Option for how to display mean values and partial dependence:
+
+        - "auto": String and categorical features are drawn as points, numerical ones
+          as lines.
+        - "all": All types of features are drawn as lines.
 
     Returns
     -------
@@ -815,6 +822,10 @@ def plot_marginal(
             "The ax argument must be None, a matplotlib Axes or a plotly Figure, "
             f"got {type(ax)}."
         )
+        raise ValueError(msg)
+
+    if show_lines not in ("all", "auto"):
+        msg = f"The argument show_lines mut be 'all' or 'auto'; got {show_lines}."
         raise ValueError(msg)
 
     # estimator = getattr(predict_callable, "__self__", None)
@@ -988,6 +999,13 @@ def plot_marginal(
     }
     for i, m in enumerate(plot_items):
         label = label_dict[m]
+        if plot_backend == "matplotlib":
+            linestyle = "dashed" if m == "partial_dependence" else "solid"
+        else:
+            line = {
+                "color": get_plotly_color(i),
+                "dash": "dash" if m == "partial_dependence" else None,
+            }
         if is_categorical:
             # We x-shift a little for a better visual.
             x = np.arange(n_x - feature_has_nulls)
@@ -996,7 +1014,7 @@ def plot_marginal(
                     x,
                     df_no_nulls[m],
                     marker="o",
-                    linestyle="None",
+                    linestyle="None" if show_lines == "auto" else linestyle,
                     label=label,
                 )
             else:
@@ -1004,7 +1022,8 @@ def plot_marginal(
                     x=x,
                     y=df_no_nulls[m],
                     marker={"color": get_plotly_color(i)},
-                    mode="markers",
+                    mode="markers" if show_lines == "auto" else "lines+markers",
+                    line=None if show_lines == "auto" else line,
                     name=label,
                     secondary_y=True,
                 )
@@ -1012,7 +1031,7 @@ def plot_marginal(
             ax.plot(
                 df[feature_name],
                 df[m],
-                linestyle="dashed" if m == "partial_dependence" else "solid",
+                linestyle=linestyle,
                 marker="o",
                 label=label,
             )
@@ -1022,10 +1041,7 @@ def plot_marginal(
                 y=df[m],
                 marker_symbol="circle",
                 mode="lines+markers",
-                line={
-                    "color": get_plotly_color(i),
-                    "dash": "dash" if m == "partial_dependence" else None,
-                },
+                line=line,
                 name=label,
                 secondary_y=True,
             )

--- a/src/model_diagnostics/calibration/tests/test_plots.py
+++ b/src/model_diagnostics/calibration/tests/test_plots.py
@@ -461,6 +461,7 @@ def test_plot_bias_multiple_predictions(with_null, feature_type, confidence_leve
             "XXX",
             "Parameter bin_method must be either 'quantile' or ''uniform'",
         ),
+        ("show_lines", 2, "The argument show_lines mut be 'all' or 'auto'"),
     ],
 )
 def test_plot_marginal_raises(param, value, msg):
@@ -633,3 +634,27 @@ def test_plot_marginal(with_null_values, feature_type, bin_method, ax, plot_back
         assert legend_text[2] == "partial dependence"
         if with_null_values:
             assert legend_text[-1] == "Null values"
+
+
+@pytest.mark.parametrize("show_lines", ["all", "auto"])
+@pytest.mark.parametrize("feature_type", ["num", "string"])
+@pytest.mark.parametrize("plot_backend", ["matplotlib", "plotly"])
+def test_plot_marginal_show_lines(show_lines, feature_type, plot_backend):
+    """Test that plot_marginal works with different show_lines settings."""
+    # TODO: What should we test for except that it works without error?
+    if plot_backend == "plotly":
+        pytest.importorskip("plotly")
+
+    if feature_type == "num":
+        x = np.arange(4)
+    elif feature_type == "string":
+        x = np.array(list("abcd"))
+    with config_context(plot_backend=plot_backend):
+        plot_marginal(
+            y_obs=np.arange(4),
+            y_pred=np.arange(4),
+            X=x[:, None],
+            feature_name=0,
+            predict_function=lambda x: np.arange(len(x)),
+            show_lines=show_lines,
+        )

--- a/src/model_diagnostics/calibration/tests/test_plots.py
+++ b/src/model_diagnostics/calibration/tests/test_plots.py
@@ -461,7 +461,7 @@ def test_plot_bias_multiple_predictions(with_null, feature_type, confidence_leve
             "XXX",
             "Parameter bin_method must be either 'quantile' or ''uniform'",
         ),
-        ("show_lines", 2, "The argument show_lines mut be 'all' or 'auto'"),
+        ("show_lines", 2, "The argument show_lines mut be 'always' or 'numerical'"),
     ],
 )
 def test_plot_marginal_raises(param, value, msg):
@@ -636,12 +636,11 @@ def test_plot_marginal(with_null_values, feature_type, bin_method, ax, plot_back
             assert legend_text[-1] == "Null values"
 
 
-@pytest.mark.parametrize("show_lines", ["all", "auto"])
+@pytest.mark.parametrize("show_lines", ["always", "numerical"])
 @pytest.mark.parametrize("feature_type", ["num", "string"])
 @pytest.mark.parametrize("plot_backend", ["matplotlib", "plotly"])
 def test_plot_marginal_show_lines(show_lines, feature_type, plot_backend):
     """Test that plot_marginal works with different show_lines settings."""
-    # TODO: What should we test for except that it works without error?
     if plot_backend == "plotly":
         pytest.importorskip("plotly")
 
@@ -650,7 +649,7 @@ def test_plot_marginal_show_lines(show_lines, feature_type, plot_backend):
     elif feature_type == "string":
         x = np.array(list("abcd"))
     with config_context(plot_backend=plot_backend):
-        plot_marginal(
+        ax = plot_marginal(
             y_obs=np.arange(4),
             y_pred=np.arange(4),
             X=x[:, None],
@@ -658,3 +657,29 @@ def test_plot_marginal_show_lines(show_lines, feature_type, plot_backend):
             predict_function=lambda x: np.arange(len(x)),
             show_lines=show_lines,
         )
+
+    if plot_backend == "matplotlib":
+        from matplotlib.lines import Line2D
+
+        # Filter 3 Line2d children for the 3 lines for mean y_obs, mean y_pred, pd
+        lines = [x for x in ax.get_children() if isinstance(x, Line2D)]
+        assert len(lines) == 3
+        if show_lines == "always" or feature_type == "num":
+            assert lines[0].get_linestyle() == "-"
+            assert lines[1].get_linestyle() == "-"
+            assert lines[2].get_linestyle() == "--"
+        else:
+            for i in range(3):
+                assert lines[i].get_linestyle() == "None"
+    else:
+        from plotly.graph_objs import Scatter
+
+        mode = (
+            "lines+markers"
+            if show_lines == "always" or feature_type == "num"
+            else "markers"
+        )
+        # Data elements 1, 2, 3 are the lines for mean y_obs, mean y_pred, pd
+        for i in range(1, 1 + 3):
+            assert isinstance(ax.data[i], Scatter)
+            assert ax.data[i].mode == mode


### PR DESCRIPTION
Fixes #177.
`plot_marginal` gets a new argument `show_lines` with options:
- `"always"`
- `"numerical"`