### PR TITLE
ENH add numpy binning options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,8 +269,8 @@ name."py3.11".set-extra-dependencies = [
 ]
 # Latest versions, with plotly
 name."py3.12".set-extra-dependencies = [
-  "numpy>=2.0.0",
-  "polars>=1.4.1",
+  "numpy>=2.2.0",
+  "polars>=1.21.0",
   "scipy",
   "pandas",
   "plotly",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,7 +196,7 @@ lab = "jupyter lab"
 detached = true
 dependencies = [
   "numpy>=1.22",
-  "mypy>=1.4",
+  "mypy>=1.14",
   "ruff==0.4.4",
 ]
 

--- a/src/model_diagnostics/_utils/isotonic.py
+++ b/src/model_diagnostics/_utils/isotonic.py
@@ -383,7 +383,7 @@ def isotonic_regression(
             msg = "Weights w must be strictly positive."
             raise ValueError(msg)
 
-    order = np.s_[:] if increasing else np.s_[::-1]
+    order = np.s_[:] if increasing else np.s_[::-1]  # type: ignore
     x = y[order]
     wx = weights[order]
 

--- a/src/model_diagnostics/_utils/tests/test_binning.py
+++ b/src/model_diagnostics/_utils/tests/test_binning.py
@@ -1,0 +1,184 @@
+from importlib.metadata import version
+
+import numpy as np
+import polars as pl
+import pytest
+from packaging.version import Version, parse
+from polars.testing import assert_series_equal
+
+from model_diagnostics._utils.binning import bin_feature
+
+
+def test_bin_feature_raises():
+    feature = np.arange(5)
+    msg = "Parameter bin_method must be one of .*quantile"
+    with pytest.raises(ValueError, match=msg):
+        bin_feature(
+            feature=feature,
+            feature_name=None,
+            n_obs=feature.shape[0],
+            bin_method="wrong",
+        )
+
+
+@pytest.mark.parametrize("with_null", [False, True])
+@pytest.mark.parametrize("feature_type", ["str", "cat", "enum"])
+@pytest.mark.parametrize("n_bins", [3, 5])
+@pl.StringCache()
+def test_binning_strings_categorical(with_null, feature_type, n_bins):
+    """Test that binning works for strings, categoricals, enums."""
+    feature = pl.Series(name="my_feature", values=["a", "b", "c"] * 3 + ["e"])
+    if with_null:
+        feature[0] = None
+        assert feature.has_nulls()
+        rest_name = "rest-3"
+        f_binned_expected = pl.Series(
+            name="bin", values=["rest-3", "b", "rest-3"] * 3 + ["rest-3"]
+        )
+        f_binned_expected[0] = None
+    else:
+        rest_name = "rest-2"
+        f_binned_expected = pl.Series(
+            name="bin", values=["a", "b", "rest-2"] * 3 + ["rest-2"]
+        )
+    if feature_type == "cat":
+        feature = feature.cast(pl.Categorical)
+        f_binned_expected = f_binned_expected.cast(pl.Categorical)
+    elif feature_type == "enum":
+        feature = feature.cast(pl.Enum(["b", "a", "c", "e"]))
+        f_binned_expected = f_binned_expected.cast(
+            pl.Enum(["b", "a", "c", "e", rest_name])
+        )
+    n_obs = len(feature)
+
+    if n_bins > 4:
+        f_binned_expected = pl.Series(name="bin", values=feature)
+
+    feature, n_bins_, f_binned = bin_feature(
+        feature=feature,
+        feature_name=feature.name,
+        n_obs=n_obs,
+        n_bins=n_bins,
+        bin_method="uniform",
+    )
+
+    assert isinstance(feature, pl.Series)
+    if n_bins > 3:
+        assert n_bins_ == 4 + with_null
+    else:
+        assert n_bins_ == n_bins
+    assert_series_equal(f_binned["bin"], f_binned_expected)
+
+
+@pytest.mark.parametrize(
+    "bin_method",
+    [
+        "quantile",
+        "uniform",
+        "auto",
+        "fd",
+        "doane",
+        "scott",
+        "stone",
+        "rice",
+        "sturges",
+        "sqrt",
+    ],
+)
+@pytest.mark.parametrize("with_null", [False, True])
+@pytest.mark.parametrize(
+    ("feature_type", "with_inf"),
+    [
+        (pl.Float64, False),
+        (pl.Float32, True),
+        (pl.Int32, False),
+        (pl.UInt16, False),
+    ],
+)
+def test_binning_numerical(bin_method, with_inf, with_null, feature_type):
+    """Test that binning works for numerical features."""
+    n_bins = 5
+    feature = pl.Series(name="my_feature", values=np.arange(100), dtype=feature_type)
+    if with_null:
+        feature[10] = None  # somewhere in the middle
+        assert feature.has_nulls()
+    if with_inf:
+        feature[11] = np.inf  # somewhere in the middle
+        feature[12] = -np.inf  # somewhere in the middle
+    n_obs = len(feature)
+
+    feature, n_bins_, f_binned = bin_feature(
+        feature=feature,
+        feature_name=feature.name,
+        n_obs=n_obs,
+        n_bins=n_bins,
+        bin_method=bin_method,
+    )
+
+    if bin_method in ("quantile", "uniform"):
+        assert n_bins_ == n_bins
+    assert isinstance(feature, pl.Series)
+    assert isinstance(f_binned, pl.DataFrame)
+    assert f_binned.schema == pl.Schema(
+        {"bin": feature_type, "bin_edges": pl.Array(pl.Float64, shape=(2,))}
+    )
+    assert f_binned["bin"].max() + 1 + with_null == f_binned["bin"].n_unique()
+    if bin_method in ("quantile", "uniform"):
+        assert f_binned["bin"].n_unique() == n_bins
+
+    if parse(version("polars")) >= Version("1.20.0"):
+        # It might already work for earlier polars versions.
+        df = f_binned.unique().sort("bin")
+        if with_null:
+            assert df[0, 0] is None
+            assert df[0, 1] is None
+            assert df[1, 0] == 0.0
+            assert df[1, 1][0] == (-np.inf if with_inf else 0)
+            assert df[1, 1][1] > 0  # no zero-length interval
+        else:
+            assert df[0, 0] == 0.0
+            assert df[0, 1][0] == (-np.inf if with_inf else 0)
+            assert df[0, 1][1] > 0  # no zero-length interval
+        if bin_method in ("quantile", "uniform"):
+            assert df[-1, 0] == n_bins - 1 - with_null
+        assert df[-1, 1][0] < 99  # no zero-length interval
+        assert df[-1, 1][1] == np.inf if with_inf else 99
+
+
+def test_binning_auto():
+    """ "Test auto bin method"""
+    n_bins = 5
+    feature = pl.Series(name="my_feature", values=[0, 1, 1, 2])
+    n_obs = len(feature)
+
+    feature, n_bins_, f_binned = bin_feature(
+        feature=feature,
+        feature_name=feature.name,
+        n_obs=n_obs,
+        n_bins=n_bins,
+        bin_method="auto",
+    )
+    if parse(version("numpy")) >= Version("2.1.0"):
+        # https://numpy.org/doc/stable/release/2.1.0-notes.html#histogram-auto-binning-now-returns-bin-sizes-1-for-integer-input-data
+        assert n_bins_ == 2
+    else:
+        assert n_bins_ == 4
+
+
+def test_binning_strings_with_rest():
+    """Test what happens if 'rest-n' is already taken."""
+    n_bins = 3
+    feature = pl.Series(name="my_feature", values=["a", "rest-2"] * 5 + ["c", "d"] * 2)
+    f_binned_expected = pl.Series(
+        name="bin", values=["a", "rest-2"] * 5 + ["_rest-2"] * 4
+    )
+    n_obs = len(feature)
+
+    feature, n_bins_, f_binned = bin_feature(
+        feature=feature,
+        feature_name=feature.name,
+        n_obs=n_obs,
+        n_bins=n_bins,
+    )
+
+    assert_series_equal(f_binned["bin"], f_binned_expected)

--- a/src/model_diagnostics/calibration/plots.py
+++ b/src/model_diagnostics/calibration/plots.py
@@ -64,6 +64,7 @@ def plot_reliability_diagram(
         - `"median"`. Argument `level` is neglected.
         - `"expectile"`
         - `"quantile"`
+
     level : float
         The level of the expectile or quantile. (Often called \(\alpha\).)
         It must be `0 <= level <= 1`.
@@ -318,7 +319,7 @@ def plot_bias(
     functional: str = "mean",
     level: float = 0.5,
     n_bins: int = 10,
-    bin_method: str = "quantile",
+    bin_method: str = "auto",
     confidence_level: float = 0.9,
     ax: Optional[mpl.axes.Axes] = None,
 ):
@@ -357,6 +358,7 @@ def plot_bias(
         - `"median"`. Argument `level` is neglected.
         - `"expectile"`
         - `"quantile"`
+
     level : float
         The level of the expectile or quantile. (Often called \(\alpha\).)
         It must be `0 <= level <= 1`.
@@ -368,10 +370,39 @@ def plot_bias(
         number of bins might be smaller than `n_bins`. Null values are always included
         in the output, accounting for one bin. NaN values are treated as null values.
     bin_method : str
-        The method to use for finding bin edges (boundaries). Options are:
+        The method for finding bin edges (boundaries). Options using `n_bins` are:
 
-        - "quantile"
-        - "uniform"
+        - `"quantile"`
+        - `"uniform"`
+
+        Options automatically selecting the number of bins for numerical features
+        thereby using uniform bins are same options as
+        [numpy.histogram_bin_edges](https://numpy.org/doc/stable/reference/generated/numpy.histogram_bin_edges.html):
+
+        - `"auto"`
+        Minimum bin width between the `"sturges"` and `"fd"` estimators. Provides good
+        all-around performance.
+        - `"fd"` (Freedman Diaconis Estimator)
+        Robust (resilient to outliers) estimator that takes into account data
+        variability and data size.
+        - `"doane"`
+        An improved version of Sturges' estimator that works better with non-normal
+        datasets.
+        - `"scott"`
+        Less robust estimator that takes into account data variability and data size.
+        - `"stone"`
+        Estimator based on leave-one-out cross-validation estimate of the integrated
+        squared error. Can be regarded as a generalization of Scott's rule.
+        - `"rice"`
+        Estimator does not take variability into account, only data size. Commonly
+        overestimates number of bins required.
+        - `"sturges"`
+        R's default method, only accounts for data size. Only optimal for gaussian data
+        and underestimates number of bins for large non-gaussian datasets.
+        - `"sqrt"`
+        Square root (of data size) estimator, used by Excel and other programs for its
+        speed and simplicity.
+
     confidence_level : float
         Confidence level for error bars. If 0, no error bars are plotted. Value must
         fulfil `0 <= confidence_level < 1`.
@@ -711,7 +742,7 @@ def plot_marginal(
     weights: Optional[npt.ArrayLike] = None,
     *,
     n_bins: int = 10,
-    bin_method: str = "uniform",
+    bin_method: str = "auto",
     n_max: int = 1000,
     rng: Optional[Union[np.random.Generator, int]] = None,
     ax: Optional[mpl.axes.Axes] = None,
@@ -747,10 +778,39 @@ def plot_marginal(
         number of bins might be smaller than `n_bins`. Null values are always included
         in the output, accounting for one bin. NaN values are treated as null values.
     bin_method : str
-        The method to use for finding bin edges (boundaries). Options are:
+        The method for finding bin edges (boundaries). Options using `n_bins` are:
 
-        - "quantile"
-        - "uniform"
+        - `"quantile"`
+        - `"uniform"`
+
+        Options automatically selecting the number of bins for numerical features
+        thereby using uniform bins are same options as
+        [numpy.histogram_bin_edges](https://numpy.org/doc/stable/reference/generated/numpy.histogram_bin_edges.html):
+
+        - `"auto"`
+        Minimum bin width between the `"sturges"` and `"fd"` estimators. Provides good
+        all-around performance.
+        - `"fd"` (Freedman Diaconis Estimator)
+        Robust (resilient to outliers) estimator that takes into account data
+        variability and data size.
+        - `"doane"`
+        An improved version of Sturges' estimator that works better with non-normal
+        datasets.
+        - `"scott"`
+        Less robust estimator that takes into account data variability and data size.
+        - `"stone"`
+        Estimator based on leave-one-out cross-validation estimate of the integrated
+        squared error. Can be regarded as a generalization of Scott's rule.
+        - `"rice"`
+        Estimator does not take variability into account, only data size. Commonly
+        overestimates number of bins required.
+        - `"sturges"`
+        R's default method, only accounts for data size. Only optimal for gaussian data
+        and underestimates number of bins for large non-gaussian datasets.
+        - `"sqrt"`
+        Square root (of data size) estimator, used by Excel and other programs for its
+        speed and simplicity.
+
     n_max : int or None
         Used only for partial dependence computation. The number of rows to subsample
         from X. This speeds up computation, in particular for slow predict functions.
@@ -763,8 +823,8 @@ def plot_marginal(
     show_lines : str
         Option for how to display mean values and partial dependence:
 
-        - "always": Always draw lines.
-        - "numerical": String and categorical features are drawn as points, numerical
+        - `"always"`: Always draw lines.
+        - `"numerical"`: String and categorical features are drawn as points, numerical
           ones as lines.
 
     Returns

--- a/src/model_diagnostics/calibration/tests/test_plots.py
+++ b/src/model_diagnostics/calibration/tests/test_plots.py
@@ -247,7 +247,7 @@ def test_plot_reliability_diagram_constant_prediction_transform_output():
         (
             "bin_method",
             "XXX",
-            "Parameter bin_method must be either 'quantile' or ''uniform'",
+            "Parameter bin_method must be one of .*quantile",
         ),
     ],
 )
@@ -462,7 +462,7 @@ def test_plot_bias_multiple_predictions(with_null, feature_type, confidence_leve
         (
             "bin_method",
             "XXX",
-            "Parameter bin_method must be either 'quantile' or ''uniform'",
+            "Parameter bin_method must be one of .*quantile",
         ),
         ("show_lines", 2, "The argument show_lines mut be 'always' or 'numerical'"),
     ],


### PR DESCRIPTION
Closes #181.

* compute_bias, plot_bias and compute_marginal, plot_marginal
* Add binning options from numpy.histogram_bin_edges
* Change bin_method default to "auto"
* Improve handling of np.inf
* Limit to n_bins >= 2
* Merge to "rest-n" string/category