### PR TITLE
ENH change default bin_method to "sturges"

### DIFF
--- a/src/model_diagnostics/_utils/binning.py
+++ b/src/model_diagnostics/_utils/binning.py
@@ -30,7 +30,7 @@ def bin_feature(
     feature_name: Optional[Union[int, str]],
     n_obs: int,
     n_bins: int = 10,
-    bin_method: str = "quantile",
+    bin_method: str = "sturges",
 ):
     """Helper function to bin features of different dtypes.
 
@@ -45,11 +45,15 @@ def bin_feature(
     n_obs : int
         The expected length of the first dimention of feature.
     n_bins : int
-        The number of bins, at least 2, for numerical features and the maximal number
-        of (most frequent) categories shown for categorical features. Due to ties, the
-        effective number of bins might be smaller than `n_bins`. Null values are always
-        included in the output, accounting for one bin. NaN values are treated as null
-        values.
+        The number of bins, at least 2. For numerical features, `n_bins` only applies
+        when `bin_method` is set to `"quantile"` or `"uniform"`.
+        For string-like and categorical features, the most frequent values are taken.
+        Ties are dealt with by taking the first value in natural sorting order.
+        The remaining values are merged into `"other n"` with `n` indicating the unique
+        count.
+
+        I present, null values are always included in the output, accounting for one
+        bin. NaN values are treated as null values.
     bin_method : str
         The method to use for finding bin edges (boundaries). Options are:
 

--- a/src/model_diagnostics/_utils/tests/test_binning.py
+++ b/src/model_diagnostics/_utils/tests/test_binning.py
@@ -146,7 +146,7 @@ def test_binning_numerical(bin_method, with_inf, with_null, feature_type):
 
 
 def test_binning_auto():
-    """ "Test auto bin method"""
+    """Test auto bin method"""
     n_bins = 5
     feature = pl.Series(name="my_feature", values=[0, 1, 1, 2])
     n_obs = len(feature)

--- a/src/model_diagnostics/calibration/identification.py
+++ b/src/model_diagnostics/calibration/identification.py
@@ -130,7 +130,7 @@ def compute_bias(
     functional: str = "mean",
     level: float = 0.5,
     n_bins: int = 10,
-    bin_method: str = "auto",
+    bin_method: str = "sturges",
 ):
     r"""Compute generalised bias conditional on a feature.
 
@@ -172,10 +172,15 @@ def compute_bias(
         `level=0.5` and `functional="expectile"` gives the mean.
         `level=0.5` and `functional="quantile"` gives the median.
     n_bins : int
-        The number of bins for numerical features and the maximal number of (most
-        frequent) categories shown for categorical features. Due to ties, the effective
-        number of bins might be smaller than `n_bins`. Null values are always included
-        in the output, accounting for one bin. NaN values are treated as null values.
+        The number of bins, at least 2. For numerical features, `n_bins` only applies
+        when `bin_method` is set to `"quantile"` or `"uniform"`.
+        For string-like and categorical features, the most frequent values are taken.
+        Ties are dealt with by taking the first value in natural sorting order.
+        The remaining values are merged into `"other n"` with `n` indicating the unique
+        count.
+
+        I present, null values are always included in the output, accounting for one
+        bin. NaN values are treated as null values.
     bin_method : str
         The method for finding bin edges (boundaries). Options using `n_bins` are:
 
@@ -483,7 +488,7 @@ def compute_marginal(
     weights: Optional[npt.ArrayLike] = None,
     *,
     n_bins: int = 10,
-    bin_method: str = "auto",
+    bin_method: str = "sturges",
     n_max: int = 1000,
     rng: Optional[Union[np.random.Generator, int]] = None,
 ):
@@ -512,10 +517,15 @@ def compute_marginal(
         Case weights. If given, the bias is calculated as weighted average of the
         identification function with these weights.
     n_bins : int
-        The number of bins for numerical features and the maximal number of (most
-        frequent) categories shown for categorical features. Due to ties, the effective
-        number of bins might be smaller than `n_bins`. Null values are always included
-        in the output, accounting for one bin. NaN values are treated as null values.
+        The number of bins, at least 2. For numerical features, `n_bins` only applies
+        when `bin_method` is set to `"quantile"` or `"uniform"`.
+        For string-like and categorical features, the most frequent values are taken.
+        Ties are dealt with by taking the first value in natural sorting order.
+        The remaining values are merged into `"other n"` with `n` indicating the unique
+        count.
+
+        I present, null values are always included in the output, accounting for one
+        bin. NaN values are treated as null values.
     bin_method : str
         The method for finding bin edges (boundaries). Options using `n_bins` are:
 

--- a/src/model_diagnostics/calibration/plots.py
+++ b/src/model_diagnostics/calibration/plots.py
@@ -319,7 +319,7 @@ def plot_bias(
     functional: str = "mean",
     level: float = 0.5,
     n_bins: int = 10,
-    bin_method: str = "auto",
+    bin_method: str = "sturges",
     confidence_level: float = 0.9,
     ax: Optional[mpl.axes.Axes] = None,
 ):
@@ -365,10 +365,15 @@ def plot_bias(
         `level=0.5` and `functional="expectile"` gives the mean.
         `level=0.5` and `functional="quantile"` gives the median.
     n_bins : int
-        The number of bins for numerical features and the maximal number of (most
-        frequent) categories shown for categorical features. Due to ties, the effective
-        number of bins might be smaller than `n_bins`. Null values are always included
-        in the output, accounting for one bin. NaN values are treated as null values.
+        The number of bins, at least 2. For numerical features, `n_bins` only applies
+        when `bin_method` is set to `"quantile"` or `"uniform"`.
+        For string-like and categorical features, the most frequent values are taken.
+        Ties are dealt with by taking the first value in natural sorting order.
+        The remaining values are merged into `"other n"` with `n` indicating the unique
+        count.
+
+        I present, null values are always included in the output, accounting for one
+        bin. NaN values are treated as null values.
     bin_method : str
         The method for finding bin edges (boundaries). Options using `n_bins` are:
 
@@ -742,7 +747,7 @@ def plot_marginal(
     weights: Optional[npt.ArrayLike] = None,
     *,
     n_bins: int = 10,
-    bin_method: str = "auto",
+    bin_method: str = "sturges",
     n_max: int = 1000,
     rng: Optional[Union[np.random.Generator, int]] = None,
     ax: Optional[mpl.axes.Axes] = None,
@@ -773,10 +778,15 @@ def plot_marginal(
         Case weights. If given, the bias is calculated as weighted average of the
         identification function with these weights.
     n_bins : int
-        The number of bins for numerical features and the maximal number of (most
-        frequent) categories shown for categorical features. Due to ties, the effective
-        number of bins might be smaller than `n_bins`. Null values are always included
-        in the output, accounting for one bin. NaN values are treated as null values.
+        The number of bins, at least 2. For numerical features, `n_bins` only applies
+        when `bin_method` is set to `"quantile"` or `"uniform"`.
+        For string-like and categorical features, the most frequent values are taken.
+        Ties are dealt with by taking the first value in natural sorting order.
+        The remaining values are merged into `"other n"` with `n` indicating the unique
+        count.
+
+        I present, null values are always included in the output, accounting for one
+        bin. NaN values are treated as null values.
     bin_method : str
         The method for finding bin edges (boundaries). Options using `n_bins` are:
 


### PR DESCRIPTION
Numpy's "auto" does not produce good visual results for some datasets. Smaller number of bins seems to be better for graphs. Therefore select R's default method (`breaks` argument) => "sturges".