### PR TITLE
MNT increase minimum versions python 3.11, numpy 2.0.0, scipy, 1.13.1, scikit-learn 1.4.2, polars 1.1, matplotlib 3.8.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 keywords = ["machine learning", "model diagnostics", "calibration"]
 dependencies = [
-  "matplotlib>=3.6.1",
+  "matplotlib>=3.8.4",  # numpy 2 support
   "numpy>=2.0.0",
   "packaging>=23.1",
   "polars>=1.1.0",  # numpy 2 support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 description = "Tools for diagnostics and assessment of (machine learning) models"
 readme = "README.md"
 license = { file="LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Hatch",
@@ -22,11 +22,11 @@ classifiers = [
 keywords = ["machine learning", "model diagnostics", "calibration"]
 dependencies = [
   "matplotlib>=3.6.1",
-  "numpy>=1.22",  # type annotations and method arg in quantile
+  "numpy>=2.0.0",
   "packaging>=23.1",
-  "polars>=1.0.0",
-  "scikit-learn>=1.2.0",  # We rely on the set_output API.
-  "scipy>=1.10",  # scipy.stats.expectile
+  "polars>=1.1.0",  # numpy 2 support
+  "scikit-learn>=1.4.2",  # numpy 2 support
+  "scipy>=1.13.1",  # numpy 2 support
 ]
 dynamic = ["version"]
 
@@ -150,8 +150,8 @@ exclude = [
 
 [tool.hatch.envs.default]
 dependencies = [
-  "pandas>=1.5",
-  "pyarrow>=11.0.0",
+  "pandas>=2.2.2",  # numpy 2 support
+  "pyarrow>=16.0.0",  # numpy 2 support
   "pytest",
   "pytest-cov",
   "pytest-xdist",
@@ -172,9 +172,6 @@ dependencies = [
   "mkdocs-section-index>=0.3.9",
   "mkdocs-jupyter==0.24.7",  # https://github.com/danielfrg/mkdocs-jupyter/issues/212
 ]
-extra-dependencies = [
-  "scikit-learn>=1.3.0",  # for Gamma deviance in HistGradientBoostingRegressor
-]
 
 [tool.hatch.envs.docs.scripts]
 build = "mkdocs build --clean --strict {args}"
@@ -184,7 +181,6 @@ ci-build = "mkdocs gh-deploy --force {args}"
 [tool.hatch.envs.jupyter]
 extra-dependencies = [
   "jupyterlab>=4.0.4",
-  "scikit-learn>=1.3.0",
   "plotly>=5.11.0",
 ]
 
@@ -240,36 +236,36 @@ dependencies = [
 ]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
+python = ["3.11", "3.12", "3.13", "3.14"]
 
 [tool.hatch.envs.test.overrides]
-# Minimal versions (partially inherited from scikit-learn 1.2.0)
+# Minimal versions
 # but including pandas and pyarrow
-name."py3.9".set-extra-dependencies = [
-  "numpy==1.22",
-  "polars==1.0.0",
-  "scipy==1.10",
-  "pandas==1.5.*",
-  "pyarrow==11.0.*"
+name."py3.11".set-extra-dependencies = [
+  "numpy==2.0.0",
+  "polars==1.1.0",
+  "scipy==1.13.1",
+  "pandas==2.2.2",  # numpy 2 support
+  "pyarrow==16.0.*" # numpy 2 support
 ]
 # Minimal versions without pandas and pyarrow 
-name."py3.10".set-extra-dependencies = [
-  "numpy==1.22",
-  "polars==1.0.0",
-  "scipy==1.10",
+name."py3.12".set-extra-dependencies = [
+  "numpy==2.0.0",
+  "polars==1.1.0",
+  "scipy==1.13.1",
 ]
 # Some intermediate versions, with pandads but without pyarrow
-name."py3.11".set-extra-dependencies = [
-  "numpy==1.26.*",
-  "polars==1.0.*",
-  "scipy==1.12.*",
-  "pandas==2.0.*",
+name."py3.13".set-extra-dependencies = [
+  "numpy==2.1.*",
+  "polars==1.10.*",
+  "scipy==1.14.*",
+  "pandas==2.3.*",
   "plotly",
 ]
 # Latest versions, with plotly
-name."py3.12".set-extra-dependencies = [
-  "numpy>=2.2.0",
-  "polars>=1.21.0",
+name."py3.14".set-extra-dependencies = [
+  "numpy>=2.3.0",
+  "polars>=1.31.0",
   "scipy",
   "pandas",
   "plotly",

--- a/src/model_diagnostics/_utils/tests/test_partial_dependence.py
+++ b/src/model_diagnostics/_utils/tests/test_partial_dependence.py
@@ -82,16 +82,6 @@ def test_compute_partial_dependence(n_max, weights, feature_type, data_container
                     "b": X["b"].to_numpy(),
                 }
             )
-        elif feature_type == "string":
-            # TODO: With pandas 2.0.3, this does not work for strings. Get
-            # AssertionError from polars in string_column_to_ndarray.
-            # X_skl = pandas.api.interchange.from_dataframe(X). So we do it manually.
-            X_skl = pandas.DataFrame(
-                {
-                    "a": X["a"].to_numpy(),
-                    "b": X["b"].to_numpy(),
-                }
-            )
         else:
             X_skl = pandas.api.interchange.from_dataframe(X)
     else:

--- a/src/model_diagnostics/scoring/scoring.py
+++ b/src/model_diagnostics/scoring/scoring.py
@@ -142,9 +142,9 @@ class HomogeneousExpectileScore(_BaseScoringFunction):
     Examples
     --------
     >>> hes = HomogeneousExpectileScore(degree=2, level=0.1)
-    >>> hes(y_obs=[0, 0, 1, 1], y_pred=[-1, 1, 1 , 2])  # doctest: +SKIP
-    0.95
-    """  # FIXME: numpy 2.0.0, doctest skip should not be necessary.
+    >>> hes(y_obs=[0, 0, 1, 1], y_pred=[-1, 1, 1 , 2])
+    np.float64(0.95)
+    """
 
     def __init__(self, degree: float = 2, level: float = 0.5) -> None:
         self.degree = degree
@@ -268,9 +268,9 @@ class SquaredError(HomogeneousExpectileScore):
     Examples
     --------
     >>> se = SquaredError()
-    >>> se(y_obs=[0, 0, 1, 1], y_pred=[-1, 1, 1 , 2])  # doctest: +SKIP
-    0.75
-    """  # FIXME: numpy 2.0.0, doctest skip should not be necessary.
+    >>> se(y_obs=[0, 0, 1, 1], y_pred=[-1, 1, 1 , 2])
+    np.float64(0.75)
+    """
 
     def __init__(self) -> None:
         super().__init__(degree=2, level=0.5)
@@ -296,9 +296,9 @@ class PoissonDeviance(HomogeneousExpectileScore):
     Examples
     --------
     >>> pd = PoissonDeviance()
-    >>> pd(y_obs=[0, 0, 1, 1], y_pred=[2, 1, 1 , 2])  # doctest: +SKIP
-    1.6534264097200273
-    """  # FIXME: numpy 2.0.0, doctest skip should not be necessary.
+    >>> pd(y_obs=[0, 0, 1, 1], y_pred=[2, 1, 1 , 2])
+    np.float64(1.6534264097200273)
+    """
 
     def __init__(self) -> None:
         super().__init__(degree=1, level=0.5)
@@ -325,9 +325,9 @@ class GammaDeviance(HomogeneousExpectileScore):
     Examples
     --------
     >>> gd = GammaDeviance()
-    >>> gd(y_obs=[3, 2, 1, 1], y_pred=[2, 1, 1 , 2])  # doctest: +SKIP
-    0.2972674459459178
-    """  # FIXME: numpy 2.0.0, doctest skip should not be necessary.
+    >>> gd(y_obs=[3, 2, 1, 1], y_pred=[2, 1, 1 , 2])
+    np.float64(0.2972674459459178)
+    """
 
     def __init__(self) -> None:
         super().__init__(degree=0, level=0.5)
@@ -366,11 +366,9 @@ class LogLoss(_BaseScoringFunction):
     Examples
     --------
     >>> ll = LogLoss()
-    >>> ll(y_obs=[0, 0.5, 1, 1], y_pred=[0.1, 0.2, 0.8 , 0.9], weights=[1, 2, 1, 1])  # doctest: +SKIP
-    0.17603033705165635
-    """  # noqa: E501
-
-    # FIXME: numpy 2.0.0, doctest skip should not be necessary.
+    >>> ll(y_obs=[0, 0.5, 1, 1], y_pred=[0.1, 0.2, 0.8 , 0.9], weights=[1, 2, 1, 1])
+    np.float64(0.17603033705165635)
+    """
 
     @property
     def functional(self):
@@ -466,9 +464,9 @@ class HomogeneousQuantileScore(_BaseScoringFunction):
     Examples
     --------
     >>> hqs = HomogeneousQuantileScore(degree=3, level=0.1)
-    >>> hqs(y_obs=[0, 0, 1, 1], y_pred=[-1, 1, 1 , 2])  # doctest: +SKIP
-    0.6083333333333334
-    """  # FIXME: numpy 2.0.0, doctest skip should not be necessary.
+    >>> hqs(y_obs=[0, 0, 1, 1], y_pred=[-1, 1, 1 , 2])
+    np.float64(0.6083333333333334)
+    """
 
     def __init__(self, degree: float = 2, level: float = 0.5) -> None:
         self.degree = degree
@@ -569,9 +567,9 @@ class PinballLoss(HomogeneousQuantileScore):
     Examples
     --------
     >>> pl = PinballLoss(level=0.9)
-    >>> pl(y_obs=[0, 0, 1, 1], y_pred=[-1, 1, 1 , 2])  # doctest: +SKIP
-    0.275
-    """  # FIXME: numpy 2.0.0, doctest skip should not be necessary.
+    >>> pl(y_obs=[0, 0, 1, 1], y_pred=[-1, 1, 1 , 2])
+    np.float64(0.275)
+    """
 
     def __init__(self, level: float = 0.5) -> None:
         super().__init__(degree=1, level=level)
@@ -644,9 +642,9 @@ class ElementaryScore(_BaseScoringFunction):
     Examples
     --------
     >>> el_score = ElementaryScore(eta=2, functional="mean")
-    >>> el_score(y_obs=[1, 2, 2, 1], y_pred=[4, 1, 2, 3])  # doctest: +SKIP
-    0.5
-    """  # FIXME: numpy 2.0.0, doctest skip should not be necessary.
+    >>> el_score(y_obs=[1, 2, 2, 1], y_pred=[4, 1, 2, 3])
+    np.float64(0.5)
+    """
 
     def __init__(
         self, eta: float, functional: str = "mean", level: float = 0.5


### PR DESCRIPTION
MNT increase minimum version, driving factor is numpy 2, see https://github.com/numpy/numpy/issues/26191:
* python to 3.11 https://devguide.python.org/versions/
* numpy to 2.0.0, https://numpy.org/neps/nep-0029-deprecation_policy.html
* scipy 1.13.1 https://docs.scipy.org/doc/scipy/dev/toolchain.html
* scikit-learn 1.4.2 https://scikit-learn.org/stable/whats_new/v1.4.html#version-1-4-2
* polars 1.1 https://github.com/pola-rs/polars/releases/tag/py-1.1.0
* pandas 2.2.2 https://pandas.pydata.org/docs/whatsnew/v2.2.2.html#pandas-2-2-2-is-now-compatible-with-numpy-2-0
* pyarrow 16.0.0 https://arrow.apache.org/release/16.0.0.html
* matplotlb 3.8.4 https://github.com/matplotlib/matplotlib/releases/tag/v3.8.4