### PR TITLE
MNT polars deprecates dataframe interchange protocol

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,4 +298,5 @@ doctest_optionflags = [
 filterwarnings = [
   # fail on any warnings that are not explicitly matched below
   "error",
+  "ignore:Support for the dataframe interchange protocol:DeprecationWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,4 +298,5 @@ doctest_optionflags = [
 filterwarnings = [
   # fail on any warnings that are not explicitly matched below
   "error",
+  "ignore:Support for the dataframe interchange protocol:DeprecationWarning"
 ]


### PR DESCRIPTION
Without filterwarnings, this makes CI red. Should be green again. 